### PR TITLE
feat: add css 작성시 미디어쿼리 추가하는 유틸 함수

### DIFF
--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,0 +1,16 @@
+import { css, Interpolation } from 'styled-components';
+
+const breakpoints = {
+  mobile: '480px',
+  tablet: '768px',
+};
+
+type Breakpoints = keyof typeof breakpoints;
+
+export const media = (breakpoint: Breakpoints) => {
+  return (style: TemplateStringsArray, ...args: Interpolation<object>[]) => css`
+    @media (max-width: ${breakpoints[breakpoint]}) {
+      ${css(style, ...args)}
+    }
+  `;
+};


### PR DESCRIPTION
# 사용예시
```
import { media } from '@utils/media'; //유틸함수 불러오기

const StyledComponent = styled.div`
  background-color: palevioletred; // 기본 배경색
  color: white; // 기본 텍스트 색

  // 태블릿 크기 이하에서 배경색 변경

  ${media('tablet')`
    background-color: lightblue;
  `}

  // 모바일 크기 이하에서 배경색 변경
  ${media('mobile')`
    background-color: lightgreen;
  `}
`;
```