### PR TITLE
feat 아이디 이메일 인풋 프로필 인풋 완성feat deviceSize구성 feat tsconfig 에러 숨김

### DIFF
--- a/src/components/input/EmailPassword.tsx
+++ b/src/components/input/EmailPassword.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  EmailPasswordFrameStyled,
+  EmailPasswordNameStyled,
+} from './emailPasswordFrame';
+import { InputStyled } from './input';
+
+interface EmailPasswordProps {
+  name: string;
+  placeholder?: string;
+  value?: string;
+  onChange: (e: React.ChangeEvent) => void;
+}
+
+const EmailPassword = ({
+  name,
+  placeholder,
+  value,
+  onChange,
+}: EmailPasswordProps) => {
+  return (
+    <EmailPasswordFrameStyled>
+      <EmailPasswordNameStyled>{name}</EmailPasswordNameStyled>
+      <InputStyled
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
+    </EmailPasswordFrameStyled>
+  );
+};
+
+export default EmailPassword;

--- a/src/components/input/EmailPassword.tsx
+++ b/src/components/input/EmailPassword.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {
-  EmailPasswordFrameStyled,
-  EmailPasswordNameStyled,
+  StyledEmailPasswordFrame,
+  StyledEmailPasswordName,
 } from './emailPasswordFrame';
-import { InputStyled } from './input';
+import { StyledInput } from './input';
 
 interface EmailPasswordProps {
   name: string;
@@ -19,14 +19,14 @@ const EmailPassword = ({
   onChange,
 }: EmailPasswordProps) => {
   return (
-    <EmailPasswordFrameStyled>
-      <EmailPasswordNameStyled>{name}</EmailPasswordNameStyled>
-      <InputStyled
+    <StyledEmailPasswordFrame>
+      <StyledEmailPasswordName>{name}</StyledEmailPasswordName>
+      <StyledInput
         placeholder={placeholder}
         value={value}
         onChange={onChange}
       />
-    </EmailPasswordFrameStyled>
+    </StyledEmailPasswordFrame>
   );
 };
 

--- a/src/components/input/InputProfile.tsx
+++ b/src/components/input/InputProfile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { InputStyled } from './input';
-import { ProfileNameStyled, ProfileFrameStyled } from './inputProfileFrame';
+import { StyledInput } from './input';
+import { StyledProfileName, StyledProfileFrame } from './inputProfileFrame';
 
 interface inputProfileProps {
   name: string;
@@ -16,14 +16,14 @@ const InputProfile = ({
   onChange,
 }: inputProfileProps) => {
   return (
-    <ProfileFrameStyled>
-      <ProfileNameStyled>{name}</ProfileNameStyled>
-      <InputStyled
+    <StyledProfileFrame>
+      <StyledProfileName>{name}</StyledProfileName>
+      <StyledInput
         value={value}
         onChange={onChange}
         placeholder={placeholder}
       />
-    </ProfileFrameStyled>
+    </StyledProfileFrame>
   );
 };
 

--- a/src/components/input/InputProfile.tsx
+++ b/src/components/input/InputProfile.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { InputStyled } from './input';
+import { ProfileNameStyled, ProfileFrameStyled } from './inputProfileFrame';
+
+interface inputProfileProps {
+  name: string;
+  placeholder?: string;
+  value?: string;
+  onChange: (e: React.ChangeEvent) => void;
+}
+
+const InputProfile = ({
+  name,
+  placeholder,
+  value,
+  onChange,
+}: inputProfileProps) => {
+  return (
+    <ProfileFrameStyled>
+      <ProfileNameStyled>{name}</ProfileNameStyled>
+      <InputStyled
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+      />
+    </ProfileFrameStyled>
+  );
+};
+
+export default InputProfile;

--- a/src/components/input/emailPasswordFrame.ts
+++ b/src/components/input/emailPasswordFrame.ts
@@ -12,7 +12,7 @@ export const StyledEmailPasswordFrame = styled.div`
     width: 400px;
     height: 45px;
   }
-  @media (max-width: ) {
+  /* @media (max-width: ) {
   }
 
   @media (max-width: ) {
@@ -20,7 +20,7 @@ export const StyledEmailPasswordFrame = styled.div`
       width: 335px;
       height: 45px;
     }
-  }
+  } */
 `;
 
 export const StyledEmailPasswordName = styled.label`

--- a/src/components/input/emailPasswordFrame.ts
+++ b/src/components/input/emailPasswordFrame.ts
@@ -8,19 +8,6 @@ export const StyledEmailPasswordFrame = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
-  ${StyledInput} {
-    width: 400px;
-    height: 45px;
-  }
-  /* @media (max-width: ) {
-  }
-
-  @media (max-width: ) {
-    ${StyledInput} {
-      width: 335px;
-      height: 45px;
-    }
-  } */
 `;
 
 export const StyledEmailPasswordName = styled.label`

--- a/src/components/input/emailPasswordFrame.ts
+++ b/src/components/input/emailPasswordFrame.ts
@@ -1,30 +1,29 @@
 import styled from 'styled-components';
 import { theme } from '@styles/theme';
-import { DEVICE_SIZE } from '@utils/deviceSize';
-import { InputStyled } from './input';
+import { StyledInput } from './input';
 
-export const EmailPasswordFrameStyled = styled.div`
+export const StyledEmailPasswordFrame = styled.div`
   width: 400px;
   height: 79px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  ${InputStyled} {
+  ${StyledInput} {
     width: 400px;
     height: 45px;
   }
-  @media (max-width: ${DEVICE_SIZE.tablet}px) {
+  @media (max-width: ) {
   }
 
-  @media (max-width: ${DEVICE_SIZE.mobile}px) {
-    ${InputStyled} {
+  @media (max-width: ) {
+    ${StyledInput} {
       width: 335px;
       height: 45px;
     }
   }
 `;
 
-export const EmailPasswordNameStyled = styled.label`
+export const StyledEmailPasswordName = styled.label`
   font-style: ${theme.fonts['pretendard/md-14px-regular']};
   color: ${theme.colors.gray[800]};
   font-size: 14px;

--- a/src/components/input/emailPasswordFrame.ts
+++ b/src/components/input/emailPasswordFrame.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { theme } from '@styles/theme';
+import { DEVICE_SIZE } from '@utils/deviceSize';
+import { InputStyled } from './input';
+
+export const EmailPasswordFrameStyled = styled.div`
+  width: 400px;
+  height: 79px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  ${InputStyled} {
+    width: 400px;
+    height: 45px;
+  }
+  @media (max-width: ${DEVICE_SIZE.tablet}px) {
+  }
+
+  @media (max-width: ${DEVICE_SIZE.mobile}px) {
+    ${InputStyled} {
+      width: 335px;
+      height: 45px;
+    }
+  }
+`;
+
+export const EmailPasswordNameStyled = styled.label`
+  font-style: ${theme.fonts['pretendard/md-14px-regular']};
+  color: ${theme.colors.gray[800]};
+  font-size: 14px;
+`;

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { theme } from '@styles/theme';
 
-export const InputStyled = styled.input`
+export const StyledInput = styled.input`
   position: relative;
   border-radius: 10px;
   padding-left: 14px;
@@ -11,12 +11,14 @@ export const InputStyled = styled.input`
   font-style: ${theme.fonts['pretendard/md-14px-regular']};
   color: ${theme.colors.gray[800]};
   font-weight: 500;
-  border-color: #ffffffff;
+  box-sizing: border-box;
   &:focus {
     border: 1px solid ${theme.colors.main[500]};
     outline: none;
   }
   &::placeholder {
     color: ${theme.colors.gray[600]};
+    font-weight:400
+    font-size:14px
   }
 `;

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import { theme } from '@styles/theme';
+
+export const InputStyled = styled.input`
+  position: relative;
+  border-radius: 10px;
+  padding-left: 14px;
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+  background-color: ${theme.colors.gray[50]};
+  font-style: ${theme.fonts['pretendard/md-14px-regular']};
+  color: ${theme.colors.gray[800]};
+  font-weight: 500;
+  border-color: #ffffffff;
+  &:focus {
+    border: 1px solid ${theme.colors.main[500]};
+    outline: none;
+  }
+  &::placeholder {
+    color: ${theme.colors.gray[600]};
+  }
+`;

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { theme } from '@styles/theme';
+import { media } from '@utils/media';
 
 export const StyledInput = styled.input`
   position: relative;
@@ -18,7 +19,16 @@ export const StyledInput = styled.input`
   }
   &::placeholder {
     color: ${theme.colors.gray[600]};
-    font-weight:400
-    font-size:14px
+    font-weight: 400;
+    font-size: 14px;
   }
+  ${media('tablet')`
+    width:200px;
+    height:45px;
+  `}
+
+  ${media('mobile')`
+  width:200px;
+  height:35px;
+  `}
 `;

--- a/src/components/input/inputProfileFrame.ts
+++ b/src/components/input/inputProfileFrame.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { theme } from '@styles/theme';
+import { DEVICE_SIZE } from '@utils/deviceSize';
+import { InputStyled } from './input';
+
+export const ProfileFrameStyled = styled.div`
+  width: 320px;
+  height: 45px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  ${InputStyled} {
+    width: 239px;
+    height: 45px;
+  }
+  @media (max-width: ${DEVICE_SIZE.tablet}px) {
+    ${InputStyled} {
+      width: 200px;
+      height: 45px;
+    }
+  }
+  @media (max-width: ${DEVICE_SIZE.mobile}px) {
+    ${InputStyled} {
+      width: 200px;
+      height: 34px;
+    }
+  }
+`;
+
+export const ProfileNameStyled = styled.label`
+  width: 60px;
+  font-style: ${theme.fonts['pretendard/md-14px-regular']};
+  font-weight: 400;
+  font-size: 14px;
+  color: ${theme.colors.gray[600]};
+`;

--- a/src/components/input/inputProfileFrame.ts
+++ b/src/components/input/inputProfileFrame.ts
@@ -1,34 +1,33 @@
 import styled from 'styled-components';
 import { theme } from '@styles/theme';
-import { DEVICE_SIZE } from '@utils/deviceSize';
-import { InputStyled } from './input';
+import { StyledInput } from './input';
 
-export const ProfileFrameStyled = styled.div`
+export const StyledProfileFrame = styled.div`
   width: 320px;
   height: 45px;
   display: flex;
   justify-content: center;
   align-items: center;
 
-  ${InputStyled} {
+  ${StyledInput} {
     width: 239px;
     height: 45px;
   }
-  @media (max-width: ${DEVICE_SIZE.tablet}px) {
-    ${InputStyled} {
+  @media (max-width: ) {
+    ${StyledInput} {
       width: 200px;
       height: 45px;
     }
   }
-  @media (max-width: ${DEVICE_SIZE.mobile}px) {
-    ${InputStyled} {
+  @media (max-width: ) {
+    ${StyledInput} {
       width: 200px;
       height: 34px;
     }
   }
 `;
 
-export const ProfileNameStyled = styled.label`
+export const StyledProfileName = styled.label`
   width: 60px;
   font-style: ${theme.fonts['pretendard/md-14px-regular']};
   font-weight: 400;

--- a/src/components/input/inputProfileFrame.ts
+++ b/src/components/input/inputProfileFrame.ts
@@ -1,7 +1,5 @@
 import styled from 'styled-components';
 import { theme } from '@styles/theme';
-import { media } from '@utils/media';
-import { StyledInput } from './input';
 
 export const StyledProfileFrame = styled.div`
   width: 320px;
@@ -9,23 +7,6 @@ export const StyledProfileFrame = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-
-  ${StyledInput} {
-    width: 239px;
-    height: 45px;
-  }
-  ${media('tablet')`
-  
-  ${StyledInput}{
-    width:200px
-    height:45px}
-  `}
-
-  ${media('mobile')`
-   ${StyledInput}{
-  width:200px
-  height:35px}
-  `}
 `;
 
 export const StyledProfileName = styled.label`

--- a/src/components/input/inputProfileFrame.ts
+++ b/src/components/input/inputProfileFrame.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { theme } from '@styles/theme';
+import { media } from '@utils/media';
 import { StyledInput } from './input';
 
 export const StyledProfileFrame = styled.div`
@@ -13,19 +14,18 @@ export const StyledProfileFrame = styled.div`
     width: 239px;
     height: 45px;
   }
+  ${media('tablet')`
+  
+  ${StyledInput}{
+    width:200px
+    height:45px}
+  `}
 
-  @media (max-width: ) {
-    ${StyledInput} {
-      width: 200px;
-      height: 45px;
-    }
-  }
-  @media (max-width: ) {
-    ${StyledInput} {
-      width: 200px;
-      height: 34px;
-    }
-  }
+  ${media('mobile')`
+   ${StyledInput}{
+  width:200px
+  height:35px}
+  `}
 `;
 
 export const StyledProfileName = styled.label`

--- a/src/components/input/inputProfileFrame.ts
+++ b/src/components/input/inputProfileFrame.ts
@@ -13,6 +13,7 @@ export const StyledProfileFrame = styled.div`
     width: 239px;
     height: 45px;
   }
+
   @media (max-width: ) {
     ${StyledInput} {
       width: 200px;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import InputProfile from '@components/input/InputProfile';
+import { StyledProfileFrame } from '@components/input/inputProfileFrame';
 
 const Home = () => {
-  return <div>메인페이지입니다.</div>;
+  return (
+    <div>
+      메인페이지입니다.
+      <InputProfile name="테스트" value="s" onChange={() => {}} />
+    </div>
+  );
 };
 
 export default Home;

--- a/src/utils/deviceSize.ts
+++ b/src/utils/deviceSize.ts
@@ -1,4 +1,0 @@
-export const DEVICE_SIZE = {
-  tablet: 1200,
-  mobile: 769,
-};

--- a/src/utils/deviceSize.ts
+++ b/src/utils/deviceSize.ts
@@ -1,0 +1,4 @@
+export const DEVICE_SIZE = {
+  tablet: 1200,
+  mobile: 769,
+};

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,0 +1,16 @@
+import { css, Interpolation } from 'styled-components';
+
+const breakpoints = {
+  mobile: '480px',
+  tablet: '768px',
+};
+
+type Breakpoints = keyof typeof breakpoints;
+
+export const media = (breakpoint: Breakpoints) => {
+  return (style: TemplateStringsArray, ...args: Interpolation<object>[]) => css`
+    @media (max-width: ${breakpoints[breakpoint]}) {
+      ${css(style, ...args)}
+    }
+  `;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
@@ -37,4 +37,3 @@
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }
-


### PR DESCRIPTION
 - inputStyled 사용법
 입력값은  props로 width와 heigth를 받습니다. 이두개의 props로 폭과 높이 지정가능

- InputProfile 사용방법
![스크린샷 2024-06-24 오후 8 42 47](https://github.com/Codeit-Sprint-6-Team4/Team4-Wekid/assets/116941126/c887aa70-60ce-44a8-8dcc-a2e486f34ff7)
`
interface inputProfileProps {
  name: string;
  placeholder?: string;
  value?: string;
  onChange: (e: React.ChangeEvent) => void;
}`
name:라벨의 값 ex)거주지 ,MBTI
placeholder:인풋 플레이스홀더값 선택임
value:인풋의 value
onChange:인풋의 onChange메소드
반응형 적용
- EmailPassword 사용방법
![스크린샷 2024-06-24 오후 9 31 43](https://github.com/Codeit-Sprint-6-Team4/Team4-Wekid/assets/116941126/4770bf6f-0a7a-49e0-860b-a06e01039cca)
`interface EmailPasswordProps {
  name: string;
  placeholder?: string;
  value?: string;
  onChange: (e: React.ChangeEvent) => void;
}`
name:라벨의 값 ex)이름, 이메일 ,비밀번홓
placeholder:인풋 플레이스혿더값 Ex)이름을 입력하세요
value:인풋의 value
onChange:인풋의 onChange메소드
반응형 적용
