### PR TITLE
feat: Button 컴포넌트

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,121 @@
+import styled, { css } from 'styled-components';
+import { media } from '@utils/media';
+
+interface ButtonProps {
+  $primary?: boolean;
+  $secondary?: boolean;
+  $loading?: boolean;
+  $width?: string;
+  $height?: string;
+  $mobileWidth?: string;
+}
+
+const StyledButton = styled.button<ButtonProps>`
+  width: ${({ $width: width }) => width || '120px'};
+  height: ${({ $height: height }) => height || '40px'};
+  border-radius: 10px;
+  border: none;
+  font: ${(props) => props.theme.fonts['pretendard/lg-14px-semibold']};
+
+  ${(props) =>
+    props.$primary &&
+    css`
+      background-color: ${props.theme.colors.main[500]};
+      color: ${props.theme.colors.gray[0]};
+      &:disabled {
+        background-color: ${props.theme.colors.gray[300]};
+      }
+    `}
+
+  ${(props) =>
+    props.$secondary &&
+    css`
+      background-color: transparent;
+      color: ${props.theme.colors.main[500]};
+      border: 1px solid ${props.theme.colors.main[500]};
+      &:disabled {
+        color: ${props.theme.colors.gray[300]};
+        border-color: ${props.theme.colors.gray[300]};
+      }
+    `}
+
+  ${(props) =>
+    props.$loading &&
+    css`
+      background-color: ${props.theme.colors.gray[300]};
+      color: ${props.theme.colors.gray[0]};
+      cursor: not-allowed;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    `}
+    
+    ${(props) =>
+    props.$mobileWidth &&
+    media('mobile')`
+    width: ${props.$mobileWidth};
+  `}
+`;
+
+const StyledDots = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 10px;
+
+  span {
+    width: 4px;
+    height: 4px;
+    background-color: ${(props) => props.theme.colors.gray[0]};
+    border-radius: 50%;
+    margin-right: 4px;
+
+    &:nth-child(1) {
+      opacity: 0.5;
+    }
+    &:nth-child(2) {
+      opacity: 0.75;
+    }
+    &:nth-child(3) {
+      opacity: 1;
+    }
+  }
+`;
+
+const Button: React.FC<
+  ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>
+> = ({
+  children,
+  $primary,
+  $secondary,
+  $loading,
+  $width,
+  $height,
+  $mobileWidth,
+  ...props
+}) => (
+  <StyledButton
+    $primary={$primary}
+    $secondary={$secondary}
+    $loading={$loading}
+    $width={$width}
+    $height={$height}
+    $mobileWidth={$mobileWidth}
+    {...props}
+  >
+    {$loading ? (
+      <>
+        <span>편집 중</span>
+        <StyledDots>
+          <span></span>
+          <span></span>
+          <span></span>
+        </StyledDots>
+      </>
+    ) : (
+      children
+    )}
+  </StyledButton>
+);
+
+export default Button;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -62,8 +62,8 @@ declare module 'styled-components' {
       'pretendard/lg-16px-medium': string;
       'pretendard/lg-16px-regular': string;
 
-      'pretendard/md-14px-bold': string;
-      'pretendard/md-14px-semibold': string;
+      'pretendard/lg-14px-bold': string;
+      'pretendard/lg-14px-semibold': string;
       'pretendard/md-14px-medium': string;
       'pretendard/md-14px-regular': string;
 
@@ -137,8 +137,8 @@ export const theme: DefaultTheme = {
     'pretendard/lg-16px-medium': 'normal normal 500 16px/26px Pretendard',
     'pretendard/lg-16px-regular': 'normal normal 400 16px/26px Pretendard',
 
-    'pretendard/md-14px-bold': 'normal normal 700 14px/24px Pretendard',
-    'pretendard/md-14px-semibold': 'normal normal 600 14px/24px Pretendard',
+    'pretendard/lg-14px-bold': 'normal normal 700 14px/24px Pretendard',
+    'pretendard/lg-14px-semibold': 'normal normal 600 14px/24px Pretendard',
     'pretendard/md-14px-medium': 'normal normal 500 14px/24px Pretendard',
     'pretendard/md-14px-regular': 'normal normal 400 14px/24px Pretendard',
 


### PR DESCRIPTION
button 컴포넌트 만들었습니다!
확인부탁드려요...

버튼 종류, width, height, 모바일반응형width, disabled 를 props로 설정해서 쓰시면 됩니다..
*버튼들은 타블랫 반응형은 없고 모바일크기에서만 바뀌더라구요.!

그리고 theme 아주 사소한 수정 했습니다....

```
//사용 예시입니다
<Button $primary>프라이머리</Button>
<Button $primary disabled>프라이머리</Button>
<Button $primary $width='200px' $height='50px' $mobileWidth='100px'>프라이머리</Button>

<Button $secondary>세컨더리</Button>
<Button $secondary disabled={true}>세컨더리</Button>
<Button $secondary $width='200px' $height='50px'>세컨더리</Button>

<Button $loading></Button>
<Button $loading $width='160px' $height='45px'></Button>

```

[![2024-06-24-9-59-17.png](https://i.postimg.cc/rFVNxhFK/2024-06-24-9-59-17.png)](https://postimg.cc/s1LWR4Wr)