### PR TITLE
add: global-styles에 폰트 기본사이즈 16px이 되도록 설정

### DIFF
--- a/src/styles/global-styles.ts
+++ b/src/styles/global-styles.ts
@@ -18,6 +18,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   body {
+    font-size: 1.6rem;
     min-width: 375px;
     line-height: normal;
     font-size: 100%;


### PR DESCRIPTION
```
body {
    font-size: 1.6rem;
}
```
코드를 추가하여 따로 폰트 크기를 설정하지 않은경우, 기본 폰트크기가 16px이 되도록 설정했습니다.