### PR TITLE
feat: Grid.tsx Props 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Board from '@pages/Board/Board';
 import Boards from '@pages/Boards/Boards';
 import Home from '@pages/Home/Home';
 import MyWeki from '@pages/MyWeki/MyWeki';
-import SignIn from '@pages/SignIn/components/SignIn';
+import SignIn from '@pages/SignIn/SignIn';
 import SignUp from '@pages/SignUp/SignUp';
 import UpLoadBoard from '@pages/UpLoadBoard/UpLoadBoard';
 import Weki from '@pages/Weki/Weki';

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -30,7 +30,7 @@ const StyledFooter = styled.footer`
     display: flex;
     flex-wrap: wrap;
     li {
-      font-size: ${theme.fonts['pretendard/md-14px-semibold']};
+      font-size: ${theme.fonts['pretendard/lg-14px-semibold']};
     }
     &:last-child {
       gap: 20px;

--- a/src/components/layout/Grid.tsx
+++ b/src/components/layout/Grid.tsx
@@ -2,29 +2,29 @@ import React from 'react';
 import styled from 'styled-components';
 import { media } from '@utils/media';
 
-interface gridProps {
+interface GridProps {
   bgColor?: string;
   children: React.ReactNode;
 }
 
-const Grid: React.FC<gridProps> = ({ children, bgColor }) => {
+const Grid: React.FC<GridProps> = ({ children, bgColor }) => {
   return (
-    <StyledGrid bgColor={bgColor}>
+    <StyledGrid $bgColor={bgColor}>
       <StyledSection>{children}</StyledSection>
     </StyledGrid>
   );
 };
 
-const StyledGrid = styled.section<gridProps>`
+const StyledGrid = styled.section<{ $bgColor?: string }>`
   padding: 100px 0;
   display: grid;
-  background-color: ${(props) => props.bgColor || '#fff'};\
+  background-color: ${(props) => props.$bgColor || '#fff'};
   ${media('tablet')`
-  padding:50px 20px;
+    padding: 50px 20px;
   `}
 `;
 
-const StyledSection = styled.div<gridProps>`
+const StyledSection = styled.div`
   margin: 0 auto;
   width: 100%;
   max-width: 924px;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -89,7 +89,6 @@ const Home = () => {
           <br />
           내용을 확인해 봐요
         </Heading>
-
         <ImgWrap>
           <img src={LandImg5} alt="위키만들기_일러스트" />
         </ImgWrap>

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
+//Components
+import Grid from '@components/layout/Grid';
+import Layout from '@components/layout/Layout';
+import { theme } from '@styles/theme';
 
 const SignIn = () => {
-  return <div>로그인페이지</div>;
+  return (
+    <Layout>
+      <Grid bgColor={`${theme.colors.gray[800]}`}>ddssd</Grid>
+    </Layout>
+  );
 };
 
 export default SignIn;

--- a/src/pages/SignIn/components/SignIn.tsx
+++ b/src/pages/SignIn/components/SignIn.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const SignIn = () => {
-  return <div>로그인페이지</div>;
-};
-
-export default SignIn;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,4 +37,3 @@
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }
-


### PR DESCRIPTION
백그라운드 칼라를 받는 Grid Props 부분, 경고 오류 수정했습니다.

`````interface GridProps {
  bgColor?: string;
  children: React.ReactNode;
}

const Grid: React.FC<GridProps> = ({ children, bgColor }) => {
  return (
    <StyledGrid $bgColor={bgColor}>
      <StyledSection>{children}</StyledSection>
    </StyledGrid>
  );
};

const StyledGrid = styled.section<{ $bgColor?: string }>`
  padding: 100px 0;
  display: grid;
  background-color: ${(props) => props.$bgColor || '#fff'};
  ${media('tablet')`
    padding: 50px 20px;
  `}
`;
`````

