### PR TITLE
feat: textarea의 높이를 자동으로 조절하는 유틸함수

### DIFF
--- a/src/utils/autoResizeTextarea.ts
+++ b/src/utils/autoResizeTextarea.ts
@@ -1,0 +1,4 @@
+export const autoResizeTextarea = (textarea) => {
+  textarea.style.height = 'auto';
+  textarea.style.height = textarea.scrollHeight + 'px';
+};

--- a/src/utils/autoResizeTextarea.ts
+++ b/src/utils/autoResizeTextarea.ts
@@ -1,4 +1,9 @@
-export const autoResizeTextarea = (textarea) => {
+/**
+ * @description ex: autoResizeTextarea(textarea) dom에서 사용해야함
+ * @param {HTMLAreaElement} textarea 
+ */
+
+export const autoResizeTextarea = (textarea: HTMLAreaElement) => {
   textarea.style.height = 'auto';
   textarea.style.height = textarea.scrollHeight + 'px';
 };


### PR DESCRIPTION
# 사용방법

```
import { autoResizeTextarea } from '@utils/autoResizeTextarea';

autoResizeTextarea(textarea);
```

# 사용예시
```
import { autoResizeTextarea } from '@utils/autoResizeTextarea';

 const textareaRef = useRef<HTMLTextAreaElement>(null);
  const [text, setText] = useState('');

useEffect(() => {
    const textarea = textareaRef.current;
    const handleInput = () => autoResizeTextarea(textarea);

    if (textarea) {
      textarea.addEventListener('input', handleInput);
      return () => textarea.removeEventListener('input', handleInput);
    }
  }, []);
```

textarea 태그를 사용하면 대부분 필요한 함수라고 생각하여 유틸함수로 뺐습니다!