### PR TITLE
Fix 강은우 boards, wikilist 페이지 카드컴포넌트 디폴트 이미지 설정, 링크 스낵바 오류 수정

### DIFF
--- a/src/components/snackbar/Sanckbar.styled.ts
+++ b/src/components/snackbar/Sanckbar.styled.ts
@@ -24,8 +24,8 @@ export const SnackbarStyled = styled.div<SnackbarContainerProps>`
         : type === 'success'
           ? theme.colors.main[500]
           : theme.colors.red[500]};
-  opacity: ${({ visible }) => (visible ? 1 : 0)};
-  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  visibility: ${({ $visible }) => ($visible ? 'visible' : 'hidden')};
   position: ${({ position }) => position || 'fixed'};
   top: ${({ top }) => top || 'auto'};
   right: ${({ right }) => right || 'auto'};

--- a/src/components/snackbar/Snackbar.tsx
+++ b/src/components/snackbar/Snackbar.tsx
@@ -2,7 +2,7 @@ import { SnackbarStyled } from './Sanckbar.styled';
 
 export interface SnackbarContainerProps {
   type: 'info' | 'success' | 'error';
-  visible: boolean;
+  $visible: boolean;
   position?: string;
   top?: string;
   right?: string;
@@ -19,7 +19,7 @@ const messages = {
 
 const Snackbar = ({
   type,
-  visible,
+  $visible,
   position,
   top,
   right,
@@ -31,7 +31,7 @@ const Snackbar = ({
   return (
     <SnackbarStyled
       type={type}
-      visible={visible}
+      $visible={$visible}
       position={position}
       top={top}
       right={right}

--- a/src/components/userlink/UserLink.styled.ts
+++ b/src/components/userlink/UserLink.styled.ts
@@ -12,6 +12,7 @@ export const StyledUserLink = styled.div`
   border-radius: 10px;
   color: ${theme.colors.main[500]};
   font: ${theme.fonts['pretendard/md-14px-regular']};
+  cursor: pointer;
 
   span {
     flex: 1;

--- a/src/components/userlink/UserLink.tsx
+++ b/src/components/userlink/UserLink.tsx
@@ -28,7 +28,9 @@ const UserLink: React.FC<UserLinkProps> = ({
 
   const url = `${baseURL}${code}`;
 
-  const handleLinkClick = () => {
+
+  const handleLinkClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.stopPropagation();
     navigator.clipboard
       .writeText(url)
       .then(() => {
@@ -49,7 +51,7 @@ const UserLink: React.FC<UserLinkProps> = ({
       {copied && (
         <Snackbar
           type={type}
-          visible={snackbarVisible}
+          $visible={snackbarVisible}
           position={position}
           top={top}
           bottom={bottom}

--- a/src/pages/WekiList/components/UserCardFrame.tsx
+++ b/src/pages/WekiList/components/UserCardFrame.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import UserLink from '@components/userlink/UserLink';
+import DefaultProfileImg from '@assets/icons/icon-profile.svg';
 import {
   StyledCardContainer,
   StyledUserImage,
@@ -26,9 +27,19 @@ const UserCardFrame: React.FC<UserCardProps> = ({
   job,
   code,
 }) => {
+  const [imageError, setImageError] = useState(false);
+
+  const handleImageError = () => {
+    setImageError(true);
+  };
+
   return (
     <StyledCardContainer>
-      <StyledUserImage src={image} alt={name} />
+      {!imageError && image ? (
+        <StyledUserImage src={image} alt={name} onError={handleImageError}/>
+      ) : (
+        <StyledUserImage src={DefaultProfileImg} alt={name} />
+      )}
       <StyledInfoContainer>
         <StyledUserName>{name}</StyledUserName>
         <StyledUserDetails>

--- a/src/pages/WekiList/components/WekiListContainer.tsx
+++ b/src/pages/WekiList/components/WekiListContainer.tsx
@@ -61,7 +61,7 @@ const WekiListContainer = () => {
   };
 
   const handleProfileCardClick = (profile: ProfileType) => {
-    navigate(`/weki/${profile.code}`);
+    navigate(`/wiki/${profile.code}`);
   };
 
   return (

--- a/src/pages/WekiList/components/WekiListUI.tsx
+++ b/src/pages/WekiList/components/WekiListUI.tsx
@@ -12,6 +12,7 @@ import {
 } from './WekiList.styled';
 import { ProfileType } from './WekiListContainer';
 import WekiSeacrhBar from './WekiSeacrhBar';
+import UserLink from '@components/userlink/UserLink';
 
 interface WekiListUIProps {
   profiles: ProfileType[];
@@ -36,6 +37,7 @@ const WekiListUI: React.FC<WekiListUIProps> = ({
 }) => {
   return (
     <StyledWekiListPageContainer>
+      {/* <UserLink code={profiles[0].code} /> */}
       <WekiSeacrhBar
         placeholder="제목을 검색해 주세요"
         onChange={handleSearchChange}

--- a/src/pages/boards/components/BestArticleCard.styled.ts
+++ b/src/pages/boards/components/BestArticleCard.styled.ts
@@ -1,11 +1,12 @@
 import HeartIcon from 'public/assets/icons/icon-heart.svg';
+import ImageIcon from 'public/assets/icons/icon-image.svg'
 import styled from 'styled-components';
 import { media } from '@utils/media';
 
 export const StyledCardContainer = styled.div`
   width: 250px;
   height: 220px;
-  background-color: ${(props) => props.theme.colors.gray[50]};
+  background-color: ${(props) => props.theme.colors.gray[0]};
   border-radius: 10px;
   overflow: hidden;
   box-shadow: 0px 4px 20px 0px #00000014;
@@ -21,6 +22,24 @@ export const StyledCardImage = styled.img`
   width: 100%;
   height: 131px;
   object-fit: cover;
+`;
+
+export const StyledCardNoImage = styled.div`
+  width: 100%;
+  height: 131px;
+  background-color: ${(props) => props.theme.colors.gray[50]};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const StyledNoImageIcon = styled.div`
+  width: 25px;
+  height: 25px;
+  background-image: url(${ImageIcon});
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
 `;
 
 export const StyledCardContent = styled.div`

--- a/src/pages/boards/components/BestArticleCard.tsx
+++ b/src/pages/boards/components/BestArticleCard.tsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { formatDateString } from '@utils/formatDateString';
 import { Article } from './BoardsContainer';
 import {
   StyledCardContainer,
   StyledCardContent,
   StyledCardImage,
+  StyledCardNoImage,
   StyledCardInfo,
   StyledCardInfoContainer1,
   StyledCardInfoContainer2,
   StyledCardLikesContainer,
   StyledCardTitle,
   StyledHeartIcon,
+  StyledNoImageIcon,
 } from '@pages/Boards/components/BestArticleCard.styled';
 import { useNavigate } from 'react-router-dom';
 
@@ -21,6 +23,12 @@ interface BestPostCardProps {
 const BestArticleCard: React.FC<BestPostCardProps> = ({ article }) => {
   const navigate = useNavigate();
   const formattedDate = formatDateString(article.createdAt);
+  const [imageError, setImageError] = useState(false);
+
+  const handleImageError = () => {
+    setImageError(true);
+  };
+  
 
   const handleClick = () => {
     navigate(`/boards/${article.id}`);
@@ -28,7 +36,17 @@ const BestArticleCard: React.FC<BestPostCardProps> = ({ article }) => {
 
   return (
     <StyledCardContainer onClick={handleClick}>
-      <StyledCardImage src={article.image} alt={article.title} />
+       {!imageError && article.image ? (
+        <StyledCardImage
+          src={article.image}
+          alt={article.title}
+          onError={handleImageError}
+        />
+      ) : (
+        <StyledCardNoImage>
+          <StyledNoImageIcon />
+        </StyledCardNoImage>
+      )}
       <StyledCardContent>
         <StyledCardTitle>{article.title}</StyledCardTitle>
         <StyledCardInfoContainer1>


### PR DESCRIPTION
- 이미지 없을 때 처리가 안돼있어서 디폴트 이미지 설정하고, 
- 링크 스낵바 약간 수정해서 오류 메시지 뜨는거 해결했습니다
- 그리고 링크 커서 포인터로 바꿨습니다

- 베스트 게시글 카드 이미지 없을때 어떻게 나오는지 피그마에 안나와있어서 그냥 제마음대로..했는데 이상한거 같으면 말씀해주셍요-!

![image](https://github.com/Codeit-Sprint-6-Team4/Team4-Wekid/assets/80903685/ece26ad1-0f8b-48e4-ae8d-dd9f6c70e84d)
![image](https://github.com/Codeit-Sprint-6-Team4/Team4-Wekid/assets/80903685/53c79372-143c-4b3f-88be-e8b7bd80c5f1)
